### PR TITLE
Remove moon textures unloading

### DIFF
--- a/EnhancedSky/Scripts/MoonController.cs
+++ b/EnhancedSky/Scripts/MoonController.cs
@@ -323,16 +323,6 @@ namespace EnhancedSky
             }
             if (tempPhase != MoonPhases.New)
             {
-                
-                try
-                {
-                    Resources.UnloadAsset(moonRend.material.mainTexture);
-                }
-                catch(Exception ex)
-                {
-                    Debug.LogError(ex.Message + " | isMasser: " + isMasser);
-
-                }
                 Texture2D tempText = GetTexture(tempPhase, textureLookup);
                 if (tempText != null)
                     moonRend.material.mainTexture = tempText;


### PR DESCRIPTION
Don't unload textures provided by ModSupport, that keeps those textures into an internal cache (square moons bug).
ModSupport now takes care of unloading and removing unused textures from its cache after a while:
https://github.com/Interkarma/daggerfall-unity/pull/1671

Forums: https://forums.dfworkshop.net/viewtopic.php?f=27&t=1542&start=60#p38269